### PR TITLE
Cleaning of the module graph_border.py

### DIFF
--- a/graph_border.py
+++ b/graph_border.py
@@ -1,7 +1,7 @@
 from collections import deque
 import heapq
 
-class InducedSubtreeConfiguration(object):
+class Configuration(object):
     r"""
     Vertex status
     """
@@ -83,7 +83,7 @@ class InducedSubtreeConfiguration(object):
         self.border_size = 0
         self.vertex_status = dict()
         for v in G.vertex_iterator():
-            self.vertex_status[v] = (InducedSubtreeConfiguration.NOT_SEEN, None)
+            self.vertex_status[v] = (Configuration.NOT_SEEN, None)
         self.history = []
         assert upper_bound_strategy in ['naive', 'dist']
         self.upper_bound_strategy = upper_bound_strategy
@@ -97,17 +97,17 @@ class InducedSubtreeConfiguration(object):
         current solution can't be extend returns None. Otherwise, return a
         border vertex.
         """
-        if self.vertex_status[self.border_vertex][0] == InducedSubtreeConfiguration.BORDER:
+        if self.vertex_status[self.border_vertex][0] == Configuration.BORDER:
             return self.border_vertex
         elif self.subtree_size == 0:
             #The subtree is empty, any non rejected vertex can be add
             for v in self.vertex_status:
-                if self.vertex_status[v][0] == InducedSubtreeConfiguration.NOT_SEEN:
+                if self.vertex_status[v][0] == Configuration.NOT_SEEN:
                     return v
         else:
             #The subtree is not empty, a vertex of the border must be add
             for v in self.vertex_status:
-                if self.vertex_status[v][0] == InducedSubtreeConfiguration.BORDER:
+                if self.vertex_status[v][0] == Configuration.BORDER:
                     return v
         return None
 
@@ -123,31 +123,31 @@ class InducedSubtreeConfiguration(object):
         OUTPUT:
             Degree of the parent of v after the addition
         """
-        assert self.vertex_status[v][0] == InducedSubtreeConfiguration.BORDER or (InducedSubtreeConfiguration.BORDER, None) not in \
+        assert self.vertex_status[v][0] == Configuration.BORDER or (Configuration.BORDER, None) not in \
                 self.vertex_status.values(), "Invalid vertex to add"
         degree = 0
         for u in self.graph.neighbor_iterator(v):
             (state, info) = self.vertex_status[u]
-            if state == InducedSubtreeConfiguration.NOT_SEEN:
-                self.vertex_status[u] = (InducedSubtreeConfiguration.BORDER, None)
+            if state == Configuration.NOT_SEEN:
+                self.vertex_status[u] = (Configuration.BORDER, None)
                 self.border_size += 1
-            elif state == InducedSubtreeConfiguration.INCLUDED:
+            elif state == Configuration.INCLUDED:
                 degree = info + 1
                 self.vertex_status[u] = (state, degree)
                 if info == 1:
                     self.num_leaf -= 1
-            elif state == InducedSubtreeConfiguration.BORDER:
+            elif state == Configuration.BORDER:
                 self.border_size -= 1
                 self.num_excluded += 1
-                self.vertex_status[u] = (InducedSubtreeConfiguration.EXCLUDED, v)
+                self.vertex_status[u] = (Configuration.EXCLUDED, v)
             #If the vertices is already rejected we do nothing
-        if self.vertex_status[v][0] == InducedSubtreeConfiguration.BORDER:
+        if self.vertex_status[v][0] == Configuration.BORDER:
             #The vertex extend a current solution
-            self.vertex_status[v] = (InducedSubtreeConfiguration.INCLUDED, 1)
+            self.vertex_status[v] = (Configuration.INCLUDED, 1)
             self.border_size -= 1
         else:
             #The vertex is the first vertex to be set to INCLUDED
-            self.vertex_status[v] = (InducedSubtreeConfiguration.INCLUDED, 0)
+            self.vertex_status[v] = (Configuration.INCLUDED, 0)
         self.subtree_vertices.append(v)
         self.num_leaf += 1
         self.subtree_size += 1
@@ -163,24 +163,24 @@ class InducedSubtreeConfiguration(object):
         for u in self.graph.neighbor_iterator(v):
             (state, info) = self.vertex_status[u]
             #Impossible that state is available
-            if state == InducedSubtreeConfiguration.BORDER:
-                self.vertex_status[u] = (InducedSubtreeConfiguration.NOT_SEEN, None)
+            if state == Configuration.BORDER:
+                self.vertex_status[u] = (Configuration.NOT_SEEN, None)
                 self.border_size -= 1
-            elif state == InducedSubtreeConfiguration.INCLUDED:
+            elif state == Configuration.INCLUDED:
                 self.vertex_status[u] = (state, info - 1)
                 if info == 2:
                     self.num_leaf += 1
             #At this point the state must be EXCLUDED
             elif info == v:
-                self.vertex_status[u] = (InducedSubtreeConfiguration.BORDER, None)
+                self.vertex_status[u] = (Configuration.BORDER, None)
                 self.num_excluded -= 1
                 self.border_size += 1
         self.subtree_size -= 1
         if self.subtree_size > 0:
-            self.vertex_status[v] = (InducedSubtreeConfiguration.BORDER, None)
+            self.vertex_status[v] = (Configuration.BORDER, None)
             self.border_size += 1
         else: #We remove the last vertex from the subtree
-            self.vertex_status[v] = (InducedSubtreeConfiguration.NOT_SEEN, None)
+            self.vertex_status[v] = (Configuration.NOT_SEEN, None)
         self.num_leaf -= 1
         self.subtree_vertices.pop()
 
@@ -190,8 +190,8 @@ class InducedSubtreeConfiguration(object):
         When a vertex v has been rejected using this method,
         his value in vertex_status is set to (EXCLUDED,v)
         """
-        assert self.vertex_status[v][0] == InducedSubtreeConfiguration.BORDER or self.subtree_size == 0
-        self.vertex_status[v] = (InducedSubtreeConfiguration.EXCLUDED, v)
+        assert self.vertex_status[v][0] == Configuration.BORDER or self.subtree_size == 0
+        self.vertex_status[v] = (Configuration.EXCLUDED, v)
         if self.subtree_size != 0:
             #The element we reject is on the border
             self.border_size -= 1
@@ -206,9 +206,9 @@ class InducedSubtreeConfiguration(object):
         """
         self.num_excluded -= 1
         if self.subtree_size == 0:
-            self.vertex_status[v] = (InducedSubtreeConfiguration.NOT_SEEN, None)
+            self.vertex_status[v] = (Configuration.NOT_SEEN, None)
         else:
-            self.vertex_status[v] = (InducedSubtreeConfiguration.BORDER, None)
+            self.vertex_status[v] = (Configuration.BORDER, None)
             self.border_size += 1
 
     def undo_last_user_action(self):
@@ -218,7 +218,7 @@ class InducedSubtreeConfiguration(object):
         """
         v = self.history.pop()
         self.lp_dist_valid = False
-        if self.vertex_status[v][0] == InducedSubtreeConfiguration.INCLUDED:
+        if self.vertex_status[v][0] == Configuration.INCLUDED:
             self._remove_last_addition(v)
         else:
             self._unreject_last_manual_rejection(v)
@@ -278,7 +278,7 @@ class InducedSubtreeConfiguration(object):
                     layer = []
                 degree = 0
                 for u in self.graph.neighbor_iterator(v):
-                    if self.vertex_status[u][0] != InducedSubtreeConfiguration.EXCLUDED:
+                    if self.vertex_status[u][0] != Configuration.EXCLUDED:
                         degree += 1
                         if u not in visited:
                             queue.append((u, dist+1))
@@ -311,12 +311,12 @@ class InducedSubtreeConfiguration(object):
                 if 1 <= prev_d and prev_d < d:
                     vertices.append(layer)
                     layer = []
-                if self.vertex_status[u][0] != InducedSubtreeConfiguration.INCLUDED:
+                if self.vertex_status[u][0] != Configuration.INCLUDED:
                     layer.append(u)
                 prev_d = d
                 visited.add(u)
                 for v in self.graph.neighbor_iterator(u):
-                    if self.vertex_status[v][0] != InducedSubtreeConfiguration.EXCLUDED and not v in visited:
+                    if self.vertex_status[v][0] != Configuration.EXCLUDED and not v in visited:
                         queue.append((v,d+1))
         vertices.append(layer)
         return vertices
@@ -349,7 +349,7 @@ class InducedSubtreeConfiguration(object):
         vertices_by_dist = self.non_rejected_vertices_by_distance_with_degree()
         #Adding the leaf creator
         for (v, d) in vertices_by_dist[0]:
-            if self.vertex_status[v][0] == InducedSubtreeConfiguration.BORDER:
+            if self.vertex_status[v][0] == Configuration.BORDER:
                 current_size += 1
                 current_leaf += 1
                 self.lp_dist_dict[current_size] = current_leaf
@@ -426,7 +426,7 @@ class InducedSubtreeConfiguration(object):
 
         tree_edge = []
         for (u, v, label) in self.graph.edge_iterator():
-            if self.vertex_status[v][0] == InducedSubtreeConfiguration.INCLUDED\
+            if self.vertex_status[v][0] == Configuration.INCLUDED\
                                         == self.vertex_status[u][0]:
                 tree_edge.append((u,v))
 
@@ -439,7 +439,7 @@ class InducedSubtreeConfiguration(object):
         s = "subtree_size:%s, num_leaf:%s, border_size:%s, num_excluded:%s" %d
         return s
 
-class InducedSubtreeConfigurationForCube(InducedSubtreeConfiguration):
+class ConfigurationForCube(Configuration):
     r"""
     Specilization of graph border classes for cube
     """
@@ -455,7 +455,7 @@ class InducedSubtreeConfigurationForCube(InducedSubtreeConfiguration):
                 'naive' or 'dist')
         """
 
-        InducedSubtreeConfiguration.__init__(self, G, upper_bound_strategy)
+        Configuration.__init__(self, G, upper_bound_strategy)
         self.max_deg = max_deg
 
     def _max_degree(self, d):

--- a/graph_border.py
+++ b/graph_border.py
@@ -1,7 +1,7 @@
 from collections import deque
 import heapq
 
-class GraphBorder(object):
+class InducedSubtreeConfiguration(object):
     r"""
     Object that represent a induced subtree of a graph and the surrounding of
     this subtree. The data structure also catch up a bit of the evolution of
@@ -427,7 +427,7 @@ class GraphBorder(object):
         s = "subtree_size:%s, num_leaf:%s, border_size:%s, num_rejected:%s" %d
         return s
 
-class GraphBorderForCube(GraphBorder):
+class InducedSubtreeConfigurationForCube(InducedSubtreeConfiguration):
     r"""
     Specilization of graph border classes for cube
     """
@@ -443,7 +443,7 @@ class GraphBorderForCube(GraphBorder):
                 'naive' or 'dist')
         """
 
-        GraphBorder.__init__(self, G, upper_bound_strategy)
+        InducedSubtreeConfiguration.__init__(self, G, upper_bound_strategy)
         self.max_deg = max_deg
 
     def _max_degree(self, d):

--- a/induced_maximal_tree.py
+++ b/induced_maximal_tree.py
@@ -65,7 +65,7 @@ def ComputeL(G, upper_bound_strategy = 'dist'):
     max_leafed_tree = dict([(i,[]) for i in range(n+1)])
     L[0] = 0
     max_leafed_tree[0] = [[]]
-    B = GraphBorder(G, upper_bound_strategy)
+    B = InducedSubtreeConfiguration(G, upper_bound_strategy)
     treat_state()
     return L, max_leafed_tree
 
@@ -153,7 +153,7 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
     #Main computations
     for i in range(d-1, 2, -1):
         #Initialization of a starting configuration with a i-pode
-        B = GraphBorderForCube(G, i, upper_bound_strategy)
+        B = InducedSubtreeConfigurationForCube(G, i, upper_bound_strategy)
         B.add_to_subtree(base_vertex)
         for j in range(d):
             if j < i:

--- a/induced_maximal_tree.py
+++ b/induced_maximal_tree.py
@@ -52,12 +52,12 @@ def ComputeL(G, upper_bound_strategy = 'dist'):
                 max_leafed_tree[m] = [copy(B.subtree_vertices)]
                 L[m] = l
         elif promising:
-            B.add_to_subtree(next_vertex)
+            B.include_vertex(next_vertex)
             treat_state()
-            B.undo_last_user_action()
+            B.undo_last_operation()
             B.exclude_vertex(next_vertex)
             treat_state()
-            B.undo_last_user_action()
+            B.undo_last_operation()
 
     assert upper_bound_strategy in ['naive', 'dist']
     n = G.num_verts()
@@ -115,13 +115,13 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
                 max_leafed_tree[m] = [copy(B.subtree_vertices)]
                 L[m] = l
         elif promising:
-            degree = B.add_to_subtree(next_vertex)
+            degree = B.include_vertex(next_vertex)
             if degree <= i:
                 treat_state(max_deg)
-            B.undo_last_user_action()
+            B.undo_last_operation()
             B.exclude_vertex(next_vertex)
             treat_state(max_deg)
-            B.undo_last_user_action()
+            B.undo_last_operation()
 
     assert upper_bound_strategy in ['naive', 'dist']
     #Number of vertices in the biggest induced snake in cube
@@ -154,13 +154,13 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
     for i in range(d-1, 2, -1):
         #Initialization of a starting configuration with a i-pode
         B = ConfigurationForCube(G, i, upper_bound_strategy)
-        B.add_to_subtree(base_vertex)
+        B.include_vertex(base_vertex)
         for j in range(d):
             if j < i:
-                B.add_to_subtree(star_vertices[j])
+                B.include_vertex(star_vertices[j])
             else:
                 B.exclude_vertex(star_vertices[j])
-        B.add_to_subtree(extension_vertex)
+        B.include_vertex(extension_vertex)
         treat_state(i)
         if partial_output:
             print "Exploration for %s-pode complete at %s" %(i, str(datetime.now()))

--- a/induced_maximal_tree.py
+++ b/induced_maximal_tree.py
@@ -65,7 +65,7 @@ def ComputeL(G, upper_bound_strategy = 'dist'):
     max_leafed_tree = dict([(i,[]) for i in range(n+1)])
     L[0] = 0
     max_leafed_tree[0] = [[]]
-    B = InducedSubtreeConfiguration(G, upper_bound_strategy)
+    B = Configuration(G, upper_bound_strategy)
     treat_state()
     return L, max_leafed_tree
 
@@ -153,7 +153,7 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
     #Main computations
     for i in range(d-1, 2, -1):
         #Initialization of a starting configuration with a i-pode
-        B = InducedSubtreeConfigurationForCube(G, i, upper_bound_strategy)
+        B = ConfigurationForCube(G, i, upper_bound_strategy)
         B.add_to_subtree(base_vertex)
         for j in range(d):
             if j < i:

--- a/induced_maximal_tree.py
+++ b/induced_maximal_tree.py
@@ -42,7 +42,7 @@ def ComputeL(G, upper_bound_strategy = 'dist'):
         """
         m = B.subtree_size
         l = B.subtree_num_leaf()
-        promising = sum([L[i]<B.leaf_potential(i) for i in range(m, n+1-B.num_rejected)])>0
+        promising = sum([L[i]<B.leaf_potential(i) for i in range(m, n+1-B.num_excluded)])>0
         next_vertex = B.vertex_to_add()
         if next_vertex == None:
             #The subtree can't be extend
@@ -105,7 +105,7 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
         """
         m = B.subtree_size
         l = B.subtree_num_leaf()
-        promising = sum([L[i]<B.leaf_potential(i) for i in range(m, n+1-B.num_rejected)])>0
+        promising = sum([L[i]<B.leaf_potential(i) for i in range(m, n+1-B.num_excluded)])>0
         next_vertex = B.vertex_to_add()
         if next_vertex == None:
             #The subtree can't be extend

--- a/induced_maximal_tree.py
+++ b/induced_maximal_tree.py
@@ -55,7 +55,7 @@ def ComputeL(G, upper_bound_strategy = 'dist'):
             B.add_to_subtree(next_vertex)
             treat_state()
             B.undo_last_user_action()
-            B.reject_vertex(next_vertex)
+            B.exclude_vertex(next_vertex)
             treat_state()
             B.undo_last_user_action()
 
@@ -119,7 +119,7 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
             if degree <= i:
                 treat_state(max_deg)
             B.undo_last_user_action()
-            B.reject_vertex(next_vertex)
+            B.exclude_vertex(next_vertex)
             treat_state(max_deg)
             B.undo_last_user_action()
 
@@ -159,7 +159,7 @@ def CubeGraphLeafFunction(d, upper_bound_strategy = 'dist',
             if j < i:
                 B.add_to_subtree(star_vertices[j])
             else:
-                B.reject_vertex(star_vertices[j])
+                B.exclude_vertex(star_vertices[j])
         B.add_to_subtree(extension_vertex)
         treat_state(i)
         if partial_output:


### PR DESCRIPTION
I changed almost all lines of `graph_border.py`, but the modification are mostly formatting, typos and a bit of refactoring:

- I added constants for the four status of vertices (included, excluded, in the border or outside);
- `GraphBorder` is renamed `Configuration`;
- `GraphBorderForCube` has been removed by adding an attribute `max_degree_allowed_in_subtree` to `Configuration`;
- I renamed the attributes and functions to mirror better the article;
- A bit of reformatting of the docstrings, to follow more closely SageMath's standards (there is still some work to do);
- A bit of spacing;
- Some function have been made "private", by prefixing them with `_`, since they are not meant to be used outside the classes.

The modifications do not seem to have broken the modules:
~~~sh
$ sage -t induced_maximal_tree.py                                                        
too few successful tests, not using stored timings                                        
Running doctests with ID 2017-10-13-15-50-44-25479abe.                                    
Doctesting 1 file.    
sage -t induced_maximal_tree.py              
    [7 tests, 0.11 s] 
----------------------------------------------------------------------                    
All tests passed!     
----------------------------------------------------------------------                    
Total time for all tests: 0.2 seconds        
    cpu time: 0.1 seconds                    
    cumulative wall time: 0.1 seconds        

$ sage -t graph_border.py                                                                
too few successful tests, not using stored timings                                        
Running doctests with ID 2017-10-13-15-50-54-d07eec6c.                                    
Doctesting 1 file.    
sage -t graph_border.py                      
    [0 tests, 0.00 s] 
----------------------------------------------------------------------                    
All tests passed!     
----------------------------------------------------------------------                    
Total time for all tests: 0.0 seconds        
    cpu time: 0.0 seconds                    
    cumulative wall time: 0.0 seconds        
~~~