### PR TITLE
Removes the use of Infinity constant

### DIFF
--- a/flis_configuration.py
+++ b/flis_configuration.py
@@ -65,7 +65,7 @@ class Configuration(object):
     - ``border_vertex``: A candidate border vertex.
     """
 
-    def __init__(self, graph, upper_bound_strategy='dist', max_degree=Infinity):
+    def __init__(self, graph, upper_bound_strategy='dist', max_degree=None):
         r"""
         Constructor of an induced subtree configuration.
 
@@ -79,7 +79,8 @@ class Configuration(object):
 
         - ``graph``: The graph
         - ``upper_bound_strategy``: The strategy for the leaf potential.
-        - ``max_degree``: The maximum allowed degree.
+        - ``max_degree``: The maximum allowed degree. No maximal degree if
+          sets to ``None''.
         """
         self.graph = graph
         self.subtree_vertices = []
@@ -95,7 +96,10 @@ class Configuration(object):
         self.upper_bound_strategy = upper_bound_strategy
         self.lp_dist_valid = False
         self.border_vertex = v
-        self.max_degree_allowed_in_subtree = max_degree
+        if max_degree == None:
+            self.max_degree_allowed_in_subtree = graph.num_verts()
+        else:
+            self.max_degree_allowed_in_subtree = max_degree
 
     def vertex_to_add(self):
         r"""

--- a/flis_configuration.py
+++ b/flis_configuration.py
@@ -96,7 +96,7 @@ class Configuration(object):
         self.upper_bound_strategy = upper_bound_strategy
         self.lp_dist_valid = False
         self.border_vertex = v
-        if max_degree == None:
+        if max_degree is None:
             self.max_degree_allowed_in_subtree = graph.num_verts()
         else:
             self.max_degree_allowed_in_subtree = max_degree

--- a/flis_graphs.py
+++ b/flis_graphs.py
@@ -83,7 +83,7 @@ class FLISSolver(object):
 
         OUTPUT:
 
-        A dictionnary ``L`` representing the leaf map. If ``L[i] == None`` no
+        A dictionnary ``L`` representing the leaf map. If ``L[i] is None`` no
         induced of size ``i`` exists in ``G``.
         """
         if not self.lf:
@@ -106,20 +106,20 @@ class FLISSolver(object):
         Returns some fully leafed induced trees of ``self.graph`` of size
         ``i``.
 
-        If ``i == None``, returns a dictionnary of examples for each size.
+        If ``i is None``, returns a dictionnary of examples for each size.
 
         OUTPUT:
 
-        If ``i == None ``: A dictionnary of list of examples of fully leafed
+        If ``i is None ``: A dictionnary of list of examples of fully leafed
         trees for each size.
 
         If i an interger:  A list of examples of fully leafed trees of size
         ``i``.
         """
-        assert i in  range(self.n+1) or i == None, 'i invalid'
+        assert i in  range(self.n+1) or i is None, 'i invalid'
         if not self.flt:
             self.leaf_map()
-        if i == None:
+        if i is None:
             return self.flt
         else:
             return self.flt[i]
@@ -225,7 +225,7 @@ class FLISSolver(object):
         promising = any(self.lf[i] < C.leaf_potential(i) for i in range(m,
             self.n + 1 - C.num_excluded))
         next_vertex = C.vertex_to_add()
-        if next_vertex == None:
+        if next_vertex is None:
             if self.lf[m] == l:
                 self.flt[m].append(copy(C.subtree_vertices))
             elif self.lf[m] < l:
@@ -233,7 +233,7 @@ class FLISSolver(object):
                 self.lf[m] = l
         elif promising:
             degree = C.include_vertex(next_vertex)
-            if max_deg == None or degree <= max_deg:
+            if max_deg is None or degree <= max_deg:
                 self._explore_configuration(max_deg)
             C.undo_last_operation()
             C.exclude_vertex(next_vertex)

--- a/flis_graphs.py
+++ b/flis_graphs.py
@@ -210,12 +210,14 @@ class FLISSolver(object):
         self.lf = L
         self.flt = E
 
-    def _explore_configuration(self, max_deg=Infinity):
+    def _explore_configuration(self, max_deg=None):
         r"""
         Explores all the possible induced subtrees with maximum degree
         ``max_deg`` of ``self.graph`` and updates ``self.lf`` and ``self.flt``
         to keep track of the induced subtrees with the maximum number of
         leaves.
+
+        If ``max_deg=None'' then the subtree can have any maximal degree
         """
         C = self.configuration
         m = C.subtree_size
@@ -231,7 +233,7 @@ class FLISSolver(object):
                 self.lf[m] = l
         elif promising:
             degree = C.include_vertex(next_vertex)
-            if degree <= max_deg:
+            if max_deg == None or degree <= max_deg:
                 self._explore_configuration(max_deg)
             C.undo_last_operation()
             C.exclude_vertex(next_vertex)


### PR DESCRIPTION
I've removed the use of sage's Infinity which was in fact really time consuming. You can see the differences in timing on the picture. It is quite relevant.
![capture du 2018-02-27 16-10-02](https://user-images.githubusercontent.com/12940089/36755280-bde41000-1bd9-11e8-8945-e055b7bae961.png)
 For two graphs, you have first the timing with the code on the branch and then the timing with code on develop.